### PR TITLE
bugfix/552

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,7 @@ RUN pip install --no-cache-dir amqp \
     #&& pip install django-celery-beat \
     # See https://stackoverflow.com/questions/67409452/gunicorn-importerror-cannot-import-name-already-handled-from-eventlet-wsgi
     && pip install eventlet==0.33.0 https://github.com/benoitc/gunicorn/archive/refs/heads/master.zip#egg=gunicorn==20.1.0 \
+    && pip install dnspython==2.2.1 \
     && pip install gunicorn \
     && pip install pymysql \
     && pip install pyyaml \


### PR DESCRIPTION
- When building the Docker image, make to specifically install dnspython==2.2.1, otherwise Django crashes and the container hangs, see https://stackoverflow.com/questions/75137717/eventlet-dns-python-attribute-error-module-dns-rdtypes-has-no-attribute-any